### PR TITLE
removing Docker arm64 platform from actions

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -21,7 +21,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/dts-work-zone-data-feed:production


### PR DESCRIPTION
Error related to geopandas during docker build from github actions: [logs](https://github.com/cityofaustin/dts-work-zone-data-feed/actions/runs/11183985639/job/31093776350)
> WARNING:root:Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'

Rasterio does not provide python wheels for arm64, currently:
https://github.com/rasterio/rasterio/issues/2801

I hope this fixes it? When I run this locally I have to provide `--platform linux/amd64` on my mac to get it to build. 