### PR TITLE
AMANDA Invalid date handling

### DIFF
--- a/data_sources/amanda_closure_publishing.py
+++ b/data_sources/amanda_closure_publishing.py
@@ -162,12 +162,25 @@ def main(local_file=None):
     closures = closures.apply(get_start_end_date, axis=1)
     central_time_zone = pytz.timezone("US/Central")
     current_time = datetime.datetime.now(central_time_zone)
-    closures["start_date_dt"] = pd.to_datetime(closures["START_DATE"]).dt.tz_localize(
-        central_time_zone
+    closures["start_date_dt"] = (
+        pd.to_datetime(
+            closures["START_DATE"],
+            errors="coerce"     # Converts invalid dates to NaT
+        )
+        .dt.tz_localize(central_time_zone)
     )
-    closures["end_date_dt"] = pd.to_datetime(closures["END_DATE"]).dt.tz_localize(
-        central_time_zone
+    # Ignores rows with invalid dates
+    closures = closures.dropna(subset=["start_date_dt"])
+
+    closures["end_date_dt"] = (
+        pd.to_datetime(
+            closures["END_DATE"],
+            errors="coerce"     # Converts invalid dates to NaT
+        )
+        .dt.tz_localize(central_time_zone)
     )
+    # Ignores rows with invalid dates
+    closures = closures.dropna(subset=["end_date_dt"])
 
     work_zones = []
 

--- a/data_sources/amanda_closure_publishing.py
+++ b/data_sources/amanda_closure_publishing.py
@@ -169,8 +169,6 @@ def main(local_file=None):
         )
         .dt.tz_localize(central_time_zone)
     )
-    # Ignores rows with invalid dates
-    closures = closures.dropna(subset=["start_date_dt"])
 
     closures["end_date_dt"] = (
         pd.to_datetime(
@@ -179,7 +177,23 @@ def main(local_file=None):
         )
         .dt.tz_localize(central_time_zone)
     )
+
+    # Logging of invalid dates
+    if closures["start_date_dt"].isna().any() or closures["end_date_dt"].isna().any():
+        invalid = []
+        invalid.append(closures.loc[closures["start_date_dt"].isna(), ["FOLDERRSN", "START_DATE", "SEGMENT_ID"]])
+        invalid.append(closures.loc[closures["end_date_dt"].isna(), ["FOLDERRSN", "END_DATE", "SEGMENT_ID"]])
+        invalid = pd.concat(invalid)
+        for row in invalid.itertuples(index=False):
+            if not pd.isna(row.START_DATE):
+                logger.info(f"Invalid start date ({row.START_DATE}) for folderRSN: {row.FOLDERRSN} and segment "
+                            f"ID: {row.SEGMENT_ID}")
+            if not pd.isna(row.END_DATE):
+                logger.info(f"Invalid end date ({row.END_DATE}) for folderRSN: {row.FOLDERRSN} and segment "
+                            f"ID: {row.SEGMENT_ID}")
+
     # Ignores rows with invalid dates
+    closures = closures.dropna(subset=["start_date_dt"])
     closures = closures.dropna(subset=["end_date_dt"])
 
     work_zones = []


### PR DESCRIPTION
[Airflow error](https://austininnovation.slack.com/archives/C013G4RNJ01/p1767809085506349)

```
pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime: Out of bounds nanosecond timestamp: 2600-01-08 00:00:00, at position 113. You might want to try: ...
```

We got an invalid date input from a user in AMANDA. I think the best way to handle this is to ignore these rows and log them. I don't know if there's a better way to alert us of this but I think this is the best option.

Logging looks like: 
```
2026-01-07 12:41:10,952 INFO: Invalid start date (2600-01-08 00:00) for folderRSN: 13577619 and segment ID: 2017902
2026-01-07 12:41:10,953 INFO: Invalid start date (2600-01-08 00:00) for folderRSN: 13577619 and segment ID: 2017745
2026-01-07 12:41:10,953 INFO: Invalid start date (2600-01-08 00:00) for folderRSN: 13577619 and segment ID: 2017825
2026-01-07 12:41:10,953 INFO: Invalid start date (2600-01-08 00:00) for folderRSN: 13577619 and segment ID: 2017801
2026-01-07 12:41:10,953 INFO: Invalid start date (2600-01-08 00:00) for folderRSN: 13577619 and segment ID: 2041016
2026-01-07 12:41:10,953 INFO: Invalid start date (2600-01-08 00:00) for folderRSN: 13577619 and segment ID: 2017850
```
