### PR TITLE
Adding verified work zone dates to WZ feed

### DIFF
--- a/data_sources/amanda_closure_publishing.py
+++ b/data_sources/amanda_closure_publishing.py
@@ -34,11 +34,19 @@ FLAT_DATASET = os.getenv("FLAT_DATASET")
 
 
 def get_start_end_date(row):
+    if not pd.isnull(row["WORK_ZONE_DATES"]):
+        row["START_DATE"] = row["WORK_ZONE_DATES"]["start"] + " 00:00"
+        row["END_DATE"] = row["WORK_ZONE_DATES"]["end"] + " 23:59"
+        row["is_start_date_verified"] = True
+        row["is_end_date_verified"] = True
+        return row
     if not pd.isnull(row["EXTENSION_START_DATE"]) and not pd.isnull(
         row["EXTENSION_END_DATE"]
     ):
         row["START_DATE"] = row["EXTENSION_START_DATE"]
         row["END_DATE"] = row["EXTENSION_END_DATE"]
+    row["is_start_date_verified"] = False
+    row["is_end_date_verified"] = False
     return row
 
 
@@ -125,8 +133,11 @@ def main(local_file=None):
 
     # Get activated Work Zones from Coordinate
     logger.info("Retrieving activated work zones from Coordinate")
-    active_folder_rsns = get_activated_work_zones()
+    active_folder_rsns, work_zone_dates = get_activated_work_zones()
     logger.info(f"{len(active_folder_rsns)} Activated Work Zones retrieved")
+
+    # add workzone dates from coordinate, if they exist
+    closures["WORK_ZONE_DATES"] = closures["FOLDERRSN"].map(work_zone_dates)
 
     # Getting the list of unique street segments present in our data
     segments = closures[
@@ -220,6 +231,8 @@ def main(local_file=None):
         start_date = permit_closures["start_date_dt"].iloc[0]
         end_date = permit_closures["end_date_dt"].iloc[0]
         work_zone_type = permit_closures["WORK_ZONE_TYPE"].iloc[0]
+        start_verified = bool(permit_closures["is_start_date_verified"].iloc[0])
+        end_verified = bool(permit_closures["is_end_date_verified"].iloc[0])
 
         # Naming and description logic
         if permit_type == "RW":
@@ -262,6 +275,8 @@ def main(local_file=None):
                 end_date=end_date.tz_convert("UTC").strftime("%Y-%m-%dT%H:%M:%SZ"),
                 work_zone_type=work_zone_type,
                 workers_present=worker_presence,
+                start_date_verified=start_verified,
+                end_date_verified=end_verified,
             )
             # Closure type logic
             # This is how we convert AMANDA road closures into workzone closure types

--- a/data_sources/amanda_closure_publishing.py
+++ b/data_sources/amanda_closure_publishing.py
@@ -34,6 +34,15 @@ FLAT_DATASET = os.getenv("FLAT_DATASET")
 
 
 def get_start_end_date(row):
+    """
+    Determines the start and end date of a closure using the following logic:
+    - If dates are provided by COORDINATE, use those dates.
+    - If an extension is present, use the extension dates.
+    - Other wise, use the start and end dates of the permit.
+
+    Only coordinate dates are considered "verified".
+    """
+
     if not pd.isnull(row["WORK_ZONE_DATES"]):
         row["START_DATE"] = row["WORK_ZONE_DATES"]["start"] + " 00:00"
         row["END_DATE"] = row["WORK_ZONE_DATES"]["end"] + " 23:59"
@@ -173,35 +182,40 @@ def main(local_file=None):
     closures = closures.apply(get_start_end_date, axis=1)
     central_time_zone = pytz.timezone("US/Central")
     current_time = datetime.datetime.now(central_time_zone)
-    closures["start_date_dt"] = (
-        pd.to_datetime(
-            closures["START_DATE"],
-            errors="coerce"     # Converts invalid dates to NaT
-        )
-        .dt.tz_localize(central_time_zone)
-    )
+    closures["start_date_dt"] = pd.to_datetime(
+        closures["START_DATE"], errors="coerce"  # Converts invalid dates to NaT
+    ).dt.tz_localize(central_time_zone)
 
-    closures["end_date_dt"] = (
-        pd.to_datetime(
-            closures["END_DATE"],
-            errors="coerce"     # Converts invalid dates to NaT
-        )
-        .dt.tz_localize(central_time_zone)
-    )
+    closures["end_date_dt"] = pd.to_datetime(
+        closures["END_DATE"], errors="coerce"  # Converts invalid dates to NaT
+    ).dt.tz_localize(central_time_zone)
 
     # Logging of invalid dates
     if closures["start_date_dt"].isna().any() or closures["end_date_dt"].isna().any():
         invalid = []
-        invalid.append(closures.loc[closures["start_date_dt"].isna(), ["FOLDERRSN", "START_DATE", "SEGMENT_ID"]])
-        invalid.append(closures.loc[closures["end_date_dt"].isna(), ["FOLDERRSN", "END_DATE", "SEGMENT_ID"]])
+        invalid.append(
+            closures.loc[
+                closures["start_date_dt"].isna(),
+                ["FOLDERRSN", "START_DATE", "SEGMENT_ID"],
+            ]
+        )
+        invalid.append(
+            closures.loc[
+                closures["end_date_dt"].isna(), ["FOLDERRSN", "END_DATE", "SEGMENT_ID"]
+            ]
+        )
         invalid = pd.concat(invalid)
         for row in invalid.itertuples(index=False):
             if not pd.isna(row.START_DATE):
-                logger.info(f"Invalid start date ({row.START_DATE}) for folderRSN: {row.FOLDERRSN} and segment "
-                            f"ID: {row.SEGMENT_ID}")
+                logger.info(
+                    f"Invalid start date ({row.START_DATE}) for folderRSN: {row.FOLDERRSN} and segment "
+                    f"ID: {row.SEGMENT_ID}"
+                )
             if not pd.isna(row.END_DATE):
-                logger.info(f"Invalid end date ({row.END_DATE}) for folderRSN: {row.FOLDERRSN} and segment "
-                            f"ID: {row.SEGMENT_ID}")
+                logger.info(
+                    f"Invalid end date ({row.END_DATE}) for folderRSN: {row.FOLDERRSN} and segment "
+                    f"ID: {row.SEGMENT_ID}"
+                )
 
     # Ignores rows with invalid dates
     closures = closures.dropna(subset=["start_date_dt"])

--- a/data_sources/coordinate.py
+++ b/data_sources/coordinate.py
@@ -1,6 +1,7 @@
 import requests
 import os
-from datetime import date
+from datetime import datetime
+import pytz
 
 # API user credentials for Coordinate app
 COORDINATE_USER = os.getenv("COORDINATE_USER")
@@ -49,9 +50,10 @@ def get_activated_work_zones():
     # Get work zone start/end dates
     # This is a separate request as the above is filtered to only activated work zones
     url = f"{COORDINATE_BASE_URL}/api/map/"
+    ct_date = datetime.now(pytz.timezone("America/Chicago")).date().isoformat()
     params = {
         "type": "permit",
-        "attrs__workzone_end__gte": date.today().isoformat(),
+        "attrs__workzone_end__gte": ct_date,
     }
     response = requests.get(url, headers=headers, params=params)
     response.raise_for_status()

--- a/data_sources/coordinate.py
+++ b/data_sources/coordinate.py
@@ -1,10 +1,20 @@
 import requests
 import os
+from datetime import date
 
 # API user credentials for Coordinate app
 COORDINATE_USER = os.getenv("COORDINATE_USER")
 COORDINATE_PASSWORD = os.getenv("COORDINATE_PASSWORD")
 COORDINATE_BASE_URL = os.getenv("COORDINATE_BASE_URL")
+
+def paginate_coordinate_request(next_url, headers, data):
+    # handling pagination of 50 permits per request
+    while next_url:
+        response = requests.get(next_url, headers=headers, params={"type": "permit"})
+        response.raise_for_status()
+        data += response.json().get("results")
+        next_url = response.json().get("next")
+    return data
 
 
 def get_activated_work_zones():
@@ -29,16 +39,28 @@ def get_activated_work_zones():
     url = f"{COORDINATE_BASE_URL}/api/map/?attrs__workzone_activated=true"
     response = requests.get(url, headers=headers, params={"type": "permit"})
     response.raise_for_status()
+    data = response.json().get("results")
+    next_url = response.json().get("next")
+
+    data = paginate_coordinate_request(next_url, headers, data)
+    activated_permits = [int(permit["external_id"]) for permit in data]
+
+    # Get work zone start/end dates
+    # This is a separate request as the above is filtered to only activated work zones
+    url = f"{COORDINATE_BASE_URL}/api/map/"
+    params = {
+        "type": "permit",
+        "attrs__workzone_end__gte": date.today().isoformat(),
+    }
+    response = requests.get(url, headers=headers, params=params)
+    response.raise_for_status()
 
     data = response.json().get("results")
     next_url = response.json().get("next")
 
-    # handling pagination of 50 permits per request
-    while next_url:
-        response = requests.get(next_url, headers=headers, params={"type": "permit"})
-        response.raise_for_status()
-        data += response.json().get("results")
-        next_url = response.json().get("next")
+    data = paginate_coordinate_request(next_url, headers, data)
 
-    activated_permits = [int(permit["external_id"]) for permit in data]
-    return activated_permits
+    work_zone_dates = {}
+    for rec in data:
+        work_zone_dates[int(rec["external_id"])] = {"start":  rec["workzone_start"], "end": rec["workzone_end"]}
+    return activated_permits, work_zone_dates

--- a/data_sources/coordinate.py
+++ b/data_sources/coordinate.py
@@ -7,6 +7,7 @@ COORDINATE_USER = os.getenv("COORDINATE_USER")
 COORDINATE_PASSWORD = os.getenv("COORDINATE_PASSWORD")
 COORDINATE_BASE_URL = os.getenv("COORDINATE_BASE_URL")
 
+
 def paginate_coordinate_request(next_url, headers, data):
     # handling pagination of 50 permits per request
     while next_url:
@@ -62,5 +63,8 @@ def get_activated_work_zones():
 
     work_zone_dates = {}
     for rec in data:
-        work_zone_dates[int(rec["external_id"])] = {"start":  rec["workzone_start"], "end": rec["workzone_end"]}
+        work_zone_dates[int(rec["external_id"])] = {
+            "start": rec["workzone_start"],
+            "end": rec["workzone_end"],
+        }
     return activated_permits, work_zone_dates

--- a/data_sources/workzone.py
+++ b/data_sources/workzone.py
@@ -29,6 +29,8 @@ class WorkZone:
         :param end_date (str):UTC start date, strftime format: %Y-%m-%dT%H:%M:%SZ
         :param work_zone_type (str): work zone type in: static, moving, planned-moving-area
         :param workers_present(bool): True or False if workers are present at the time
+        :param start_date_verified (bool): True or False if the start date is verified
+        :param end_date_verified (bool): True or False if the end date is verified
         """
         self.data_source_id = data_source_id
         self.name = name
@@ -135,11 +137,11 @@ class WorkZone:
                 "description": self.description,
             }
             worker_details = {
-                    "are_workers_present": self.workers_present,
-                    "definition": ["workers-in-work-zone-working"],
-                    "method": "check-in-app",
-                    "confidence": "medium",
-                }
+                "are_workers_present": self.workers_present,
+                "definition": ["workers-in-work-zone-working"],
+                "method": "check-in-app",
+                "confidence": "medium",
+            }
             properties = {
                 "core_details": core_details,
                 "start_date": self.start_date,
@@ -179,7 +181,7 @@ class AmandaWorkZone(WorkZone):
         workers_present: bool,
         start_date_verified: bool,
         end_date_verified: bool,
-        folderrsn: int
+        folderrsn: int,
     ):
         """
         :param data_source_id (str): UUID of the data source, also shown in the feed_info section
@@ -189,6 +191,8 @@ class AmandaWorkZone(WorkZone):
         :param end_date (str):UTC start date, strftime format: %Y-%m-%dT%H:%M:%SZ
         :param work_zone_type (str): work zone type in: static, moving, planned-moving-area
         :param workers_present(bool): True or False if workers are present at the time
+        :param start_date_verified (bool): True or False if the start date is verified
+        :param end_date_verified (bool): True or False if the end date is verified
         :param folderrsn: Unique ID of this AMANDA record.
         """
         super().__init__(

--- a/data_sources/workzone.py
+++ b/data_sources/workzone.py
@@ -18,6 +18,8 @@ class WorkZone:
         end_date: str,
         work_zone_type: str,
         workers_present: bool,
+        start_date_verified: bool,
+        end_date_verified: bool,
     ):
         """
         :param data_source_id (str): UUID of the data source, also shown in the feed_info section
@@ -35,6 +37,8 @@ class WorkZone:
         self.description = description
         self.work_zone_type = work_zone_type
         self.workers_present = workers_present
+        self.start_date_verified = start_date_verified
+        self.end_date_verified = end_date_verified
 
         # Starting an empty array of segments we will add to later.
         self.segments = []
@@ -140,8 +144,8 @@ class WorkZone:
                 "core_details": core_details,
                 "start_date": self.start_date,
                 "end_date": self.end_date,
-                "is_start_date_verified": False,
-                "is_end_date_verified": False,
+                "is_start_date_verified": self.start_date_verified,
+                "is_end_date_verified": self.end_date_verified,
                 "is_start_position_verified": False,
                 "is_end_position_verified": False,
                 "location_method": "other",
@@ -173,7 +177,9 @@ class AmandaWorkZone(WorkZone):
         end_date: str,
         work_zone_type: str,
         workers_present: bool,
-        folderrsn: int,
+        start_date_verified: bool,
+        end_date_verified: bool,
+        folderrsn: int
     ):
         """
         :param data_source_id (str): UUID of the data source, also shown in the feed_info section
@@ -193,6 +199,8 @@ class AmandaWorkZone(WorkZone):
             end_date,
             work_zone_type,
             workers_present,
+            start_date_verified,
+            end_date_verified,
         )
         self.folderrsn = folderrsn
 
@@ -223,8 +231,8 @@ class AmandaWorkZone(WorkZone):
                 "description": self.description,
                 "start_date": self.start_date,
                 "end_date": self.end_date,
-                "is_start_date_verified": False,
-                "is_end_date_verified": False,
+                "is_start_date_verified": self.start_date_verified,
+                "is_end_date_verified": self.end_date_verified,
                 "is_start_position_verified": False,
                 "is_end_position_verified": False,
                 "location_method": "other",


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/27242

Gets the workzone start and end date from Coordinate and supplies it instead of permitted dates if they are available.

***
# Testing

## Running the scripts

1. Be on city VPN
2. Check out this branch: `#27242/workzone-dates`
3. Get the env file from 1pass dev vault `Work zone environment file`, name it `.env` and put it in the root of this directory. 
4. ` docker build . -t atddocker/dts-work-zone-data-feed:local` Note, if you are on Apple Silicon you may need to add `--platform linux/amd64` to get GDAL to install correctly.  
5. `docker run -it --env-file .env atddocker/dts-work-zone-data-feed:local /bin/bash`
6. Run the data publishing script: `python data_sources/amanda_closure_publishing.py --local-file wzdx_output.geojson`
7. Check [the dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Roadway-Work-Zones/qyfh-gwei/explore/query/SELECT%0A%20%20%60id%60%2C%0A%20%20%60type%60%2C%0A%20%20%60geometry%60%2C%0A%20%20%60event_type%60%2C%0A%20%20%60data_source_id%60%2C%0A%20%20%60road_names%60%2C%0A%20%20%60direction%60%2C%0A%20%20%60description%60%2C%0A%20%20%60start_date%60%2C%0A%20%20%60end_date%60%2C%0A%20%20%60is_start_date_verified%60%2C%0A%20%20%60is_end_date_verified%60%2C%0A%20%20%60is_start_position_verified%60%2C%0A%20%20%60is_end_position_verified%60%2C%0A%20%20%60location_method%60%2C%0A%20%20%60work_zone_type%60%2C%0A%20%20%60vehicle_impact%60%2C%0A%20%20%60folderrsn%60%2C%0A%20%20%60name%60%2C%0A%20%20%60are_workers_present%60%2C%0A%20%20%60are_workers_present_method%60%0AWHERE%0A%20%20%60is_start_date_verified%60%20IN%20%28%22true%22%29%0A%20%20%20%20OR%20%60is_end_date_verified%60%20IN%20%28%22true%22%29/page/filter) for some records with `is_end_date_verified` or `is_start_date_verified` set to `True` for at least some number closures (this url should have it prefiltered), note that the airflow DAG is still running so you might get your work overwritten once an hour).
8. Run the schema validator`python validation/schema_validation.py`, check that it returns `✅ data sample passes schema validation`

## Validating the schema

With the above steps you can validate the schema is correct using the schema validator script, but if you want to do yourself  you can check using the [schema](https://github.com/usdot-jpo-ode/wzdx/blob/main/schemas/4.2/WorkZoneFeed.json) + a [validator](https://www.jsonschemavalidator.net/ ). 

Note that the feed is quite large (4+MB) so this will slow to a crawl so you will likely want to run this on a subset of the work zones. 


 