### PR TITLE
make `Closure : Full Road` affect all directions by default

### DIFF
--- a/data_sources/amanda_closure_publishing.py
+++ b/data_sources/amanda_closure_publishing.py
@@ -296,6 +296,9 @@ def main(local_file=None):
                 for closure_type in amanda_closure_mapping:
                     if closure_type["amanda_closure"] in list(seg["CLOSURE_TYPE"]):
                         direction = seg[seg["CLOSURE_TYPE"] == closure_type["amanda_closure"]]["DIRECTION"].iloc[0]
+                        # If no direction is supplied but full road closure is selected, we assume it affects both directions of travel
+                        if not direction and closure_type["amanda_closure"] == "Closure : Full Road":
+                            direction = "Both Directions"
                         if segment_id in segment_lookup:
                             # If no direction is given, use the centerline.
                             if not direction:


### PR DESCRIPTION
[#29652](https://github.com/cityofaustin/atd-data-tech/issues/29652) - make "Closure : Full Road" affect all lanes of travel in WZDX

We relied on the direction of travel field being populated for "Closure : Full Road" to have a directionality defined, now if there is no directionality defined we assume it affects all lanes of travel.

Before (4 full road closures with directionality):
<img width="1506" height="793" alt="Screenshot 2026-08-04 at 2 41 48 PM" src="https://github.com/user-attachments/assets/09d23833-4224-4f8b-b5c7-ef0884023da3" />

After (378 full road closures with directionality):
<img width="1508" height="794" alt="Screenshot 2026-08-04 at 2 43 58 PM" src="https://github.com/user-attachments/assets/56d270ef-f44e-4130-b2fc-f1a47aaf9733" />


## Testing

**I'm not super sure if we need to test a change of this size but if you would like to:**


1. Be on city VPN
2. Check out this branch: `#29652-full-closure-both-directions`
3. Get the env file from 1pass dev vault `Work zone environment file`, name it `.env` and put it in the root of this directory. 
4. 
```bash
docker build . -t atddocker/dts-work-zone-data-feed:local
```
Note, if you are on Apple Silicon you may need to add `--platform linux/amd64` to get GDAL to install correctly.  
5. 
```bash
docker run -it --env-file .env atddocker/dts-work-zone-data-feed:local /bin/bash
```
6. Check this [map](https://datahub.austintexas.gov/Transportation-and-Mobility/AMANDA-Roadway-Work-Zones/m39r-fuyi) and check how many _directional_ full road closures there are. You can use the above screenshots to see what fields need to filtered.
7. Run the data publishing script: 
```bash
python data_sources/amanda_closure_publishing.py
```
8.  Now, refresh the same [map](https://datahub.austintexas.gov/Transportation-and-Mobility/AMANDA-Roadway-Work-Zones/m39r-fuyi) and see that there are way more directional full road closures and no "unknown" direction closures.

Just note that the [prod airflow DAG](https://airflow.austinmobility.io/dags/dts_work_zone_data_feed) runs at the top of the hour so it will undo your work around that time. If someone has tested it before you, but prior to the top of the next hour you might still see their changes in the dataset 🤷‍♂️ 
